### PR TITLE
AVWVAPI-313 fixes a switch statement

### DIFF
--- a/src/Http/Controllers/DuplicateController.php
+++ b/src/Http/Controllers/DuplicateController.php
@@ -82,7 +82,7 @@ class DuplicateController extends Controller
                     case HasOne::class:
                     case MorphOne::class:
                         if (!$items) {
-                            continue;
+                            continue 2;
                         }
 
                         // clean up our models, remove the id and remove the appends


### PR DESCRIPTION
[![JIRA Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fprobot-netsells.node.ns-client.xyz%2Fbadge%2FAVWVAPI-313)](https://netsells.atlassian.net/browse/AVWVAPI-313)

## Overview
- [x] I have performed a self review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging

### Problem statement
The error message: `"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?`

### Solution
Replaced the `continue` statement that is the inside a switch statement that is nested in foreach loop with `continue 2` statement.

### Dependencies
N/A

### Test procedures
N/A

### Links

JIRA: https://netsells.atlassian.net/browse/AVWVAPI-313

## Deployment

### Migrations
No

### Environment variables
N/A

### Deployment notes
N/A
